### PR TITLE
DPSPS-1221: Improvements to support EVW.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,13 +31,14 @@ lazy val root = (project in file("."))
       "org.typelevel"   %% "munit-cats-effect-3" % MunitCatsEffectVersion % Test,
       "ch.qos.logback"  %  "logback-classic"     % LogbackVersion         % Runtime,
       "org.scalameta"   %% "svm-subs"            % "20.2.0",
-      "uk.gov.homeoffice" %% "rtp-email-lib"     % "3.4.30-g1f7d65c",
+      "uk.gov.homeoffice" %% "rtp-email-lib"     % "3.4.31-g6787142",
       "com.typesafe"     % "config"              % "1.4.0",
       "ch.qos.logback"   %  "logback-classic"    % "1.2.3",
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
       "com.github.eikek" %% "emil-common" % "0.13.0",
       "com.github.eikek" %% "emil-javamail" % "0.13.0",
-      "uk.gov.service.notify" % "notifications-java-client" % "3.19.1-RELEASE"
+      "uk.gov.service.notify" % "notifications-java-client" % "3.19.1-RELEASE",
+      "com.outr" %% "hasher" % "1.2.2"
     ),
     addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.13.2" cross CrossVersion.full),
     addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1"),

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -40,6 +40,9 @@ app {
   # leaks confidential info
   templateDebug = "false"
   templateDebug = ${?TEMPLATE_DEBUG}
+
+  updateTokenSecret = "download_token_secret"
+  updateTokenSecret = ${?UPDATE_TOKEN_SECRET}
 }
 
 govNotify {

--- a/src/main/scala/uk/gov/homeoffice/rtemailer/Util.scala
+++ b/src/main/scala/uk/gov/homeoffice/rtemailer/Util.scala
@@ -1,9 +1,39 @@
 package uk.gov.homeoffice.rtemailer
 
+import com.mongodb.casbah.commons.MongoDBObject
+import org.joda.time.DateTime
+import org.bson.types.ObjectId
+import com.mongodb.casbah.commons.MongoDBList
+
+import uk.gov.homeoffice.rtemailer.model._
+
 object Util {
 
   implicit class JavaOptionalOps[A](val underlying :java.util.Optional[A]) extends AnyVal {
     def asScalaOption() :Option[A] = if (underlying.isEmpty) None else Some(underlying.get())
+  }
+
+  implicit class ScalaMapOps(val underlying :Map[String, String]) extends AnyVal {
+    def asJavaMap() :java.util.HashMap[String, Object] = {
+      val javaMap = new java.util.HashMap[String, Object]()
+      underlying.foreach { case (k, v) => javaMap.put(k, v) }
+      javaMap
+    }
+  }
+
+  def extractDBField(dbObj :MongoDBObject, fieldName :String) :Option[TemplateLookup] = {
+    import com.mongodb.casbah.Imports._
+
+    scala.util.Try(dbObj.getAs[Any](fieldName).map {
+      case d :org.joda.time.DateTime => TDate(d)
+      case d :java.util.Date => TDate(new DateTime(d))
+      // currently only support for lists of strings.
+      case l :MongoDBList => TList(l.map(_.toString).toList)
+      case o :ObjectId => TString(o.toHexString)
+      case true => TString("yes")
+      case false => TString("no")
+      case anyStringable => TString(anyStringable.toString())
+    }).toOption.flatten
   }
 
 }

--- a/src/main/scala/uk/gov/homeoffice/rtemailer/govnotify/GovNotifyClientWrapper.scala
+++ b/src/main/scala/uk/gov/homeoffice/rtemailer/govnotify/GovNotifyClientWrapper.scala
@@ -1,0 +1,61 @@
+package uk.gov.homeoffice.rtemailer.govnotify
+
+import cats.effect._
+import com.typesafe.scalalogging.StrictLogging
+import uk.gov.service.notify.{NotificationClient, Template, TemplatePreview, SendEmailResponse}
+import uk.gov.homeoffice.rtemailer.model._
+import uk.gov.homeoffice.domain.core.email.Email
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+class GovNotifyClientWrapper(implicit appContext :AppContext) extends StrictLogging {
+  import uk.gov.homeoffice.rtemailer.Util._
+
+  lazy val notifyClient = new NotificationClient(appContext.config.getString("govNotify.apiKey"))
+
+  def getAllTemplates() :IO[Either[GovNotifyError, List[Template]]] = {
+    IO.blocking(Try(notifyClient.getAllTemplates("email").getTemplates().asScala.toList)
+      .toEither
+      .map { templates =>
+        val templateNames = templates.map(_.getName()).mkString(",")
+        logger.info(s"Templates returned from gov notify: $templateNames")
+        templates
+      }
+      .left.map(exc => GovNotifyError(s"Error calling GovNotify.getAllTemplates: ${exc.getMessage}"))
+    )
+  }
+
+  def generateTemplatePreview(template :Template, personalisations :Map[String, String]) :IO[Either[GovNotifyError, TemplatePreview]] = {
+    IO.blocking(Try(notifyClient.generateTemplatePreview(
+      template.getId().toString(),
+      personalisations.asJavaMap(),
+    )).toEither match {
+      case Left(exc) =>
+        appContext.updateAppStatus(_.recordGovNotifyError(s"Error calling GovNotify.generateTemplatePreview: ${exc.getMessage}"))
+        Left(GovNotifyError(s"Error calling GovNotify.generateTemplatePreview: ${exc.getMessage}"))
+      case Right(templatePreview) =>
+        appContext.updateAppStatus(_.markGovNotifyOk)
+        Right(templatePreview)
+      }
+    )
+  }
+
+  def sendEmail(email :Email, template :Template, allPersonalisations :Map[String, String]) :IO[Either[GovNotifyError, SendEmailResponse]] = {
+    IO.blocking(Try(notifyClient.sendEmail(
+      template.getId().toString(),
+      email.recipient,
+      allPersonalisations.asJavaMap(),
+      email.emailId,
+    ))
+      .toEither match {
+        case Left(exc) =>
+          appContext.updateAppStatus(_.recordGovNotifyError(s"Error calling GovNotify.sendEmail: ${exc.getMessage}"))
+          Left(GovNotifyError(s"Error calling GovNotify.sendEmail: ${exc.getMessage}"))
+        case Right(sendEmailResponse) =>
+          appContext.updateAppStatus(_.markGovNotifyOk)
+          Right(sendEmailResponse)
+      }
+    )
+  }
+}
+

--- a/src/main/scala/uk/gov/homeoffice/rtemailer/model/TemplateFunctions.scala
+++ b/src/main/scala/uk/gov/homeoffice/rtemailer/model/TemplateFunctions.scala
@@ -5,57 +5,97 @@ import org.joda.time.format.DateTimeFormat
 import scala.annotation.tailrec
 import scala.util.Try
 
+sealed trait TemplateLookup { def stringValue() :Either[GovNotifyError, String] }
+case class TString(string :String) extends TemplateLookup { override def stringValue() = Right(string) }
+case class TList(list :List[String]) extends TemplateLookup { override def stringValue() = Left(GovNotifyError("Use csvList function to stringify TList object")) }
+case class TDate(date :DateTime) extends TemplateLookup { override def stringValue() = Right(date.toString("dd MMMM yyyy")) }
+
 class TemplateFunctions(implicit appContext: AppContext) {
 
   val dtf = DateTimeFormat.forPattern("dd MMMM yyyy")
 
   // We advertise to our users that we return blank/empty string if a function or field
-  // does not work. for example gtHello would fail because hello is not an Int.
+  // does not work. for example "gtHello" would fail because "Hello" is not an Int.
   // However please return GovNotifyError instead of an empty string in a failure so
   // the calling function can attach the template name to a debug message and print it out.
+  // Returning empty string on failure is done elsewhere.
 
-  def applyFunction(value :String, function :String) :Either[GovNotifyError, String] = {
-
+  def applyStringFunction(value :TString, function :String) :Either[GovNotifyError, TemplateLookup] = {
     val Right = "right(\\d+)".r
-    val Minus = "minus(Days|Weeks|Months|Years|N)(\\d+)".r
-    val Plus = "plus(Days|Weeks|Months|Years|N)(\\d+)".r
+    val MinusN = "minusN(\\d+)".r
+    val PlusN = "plusN(\\d+)".r
     val GreaterThan = "gt(\\d+)".r
     val Contains = "contains(.*)".r
 
-    def valueAsDate() = dtf.parseDateTime(value)
-    def modifyAsDate(dateModFunc :DateTime => DateTime) = dtf.print(dateModFunc(valueAsDate()))
-
     Try(function match {
-      case Right(count) => value.takeRight(count.toInt)
-      case Minus("Days", days) => modifyAsDate(_.minusDays(days.toInt))
-      case Minus("Weeks", weeks) => modifyAsDate(_.minusWeeks(weeks.toInt))
-      case Minus("Months", months) => modifyAsDate(_.minusMonths(months.toInt))
-      case Minus("Years", years) => modifyAsDate(_.minusYears(years.toInt))
-      case Plus("Days", days) => modifyAsDate(_.plusDays(days.toInt))
-      case Plus("Weeks", weeks) => modifyAsDate(_.plusWeeks(weeks.toInt))
-      case Plus("Months", months) => modifyAsDate(_.plusMonths(months.toInt))
-      case Plus("Years", years) => modifyAsDate(_.plusYears(years.toInt))
-      case "beforeNow" => if (valueAsDate().isBefore(appContext.nowF())) "yes" else "no"
-      case GreaterThan(gtInt) => if (value.toInt > gtInt.toInt) "yes" else "no"
-      case Contains(inStr) => if (value.contains(inStr)) "yes" else "no"
-      case Minus("N", int) => (value.toInt - int.toInt).toString
-      case Plus("N", int) => (value.toInt + int.toInt).toString
-      case "bool" => if (value == "true") "yes" else "no"
-      case "lower" => value.toLowerCase
-      case "upper" => value.toUpperCase
-      case "title" => value.take(1).toUpperCase + value.drop(1).toLowerCase
-      case "empty" => if (value.isEmpty) "yes" else "no"
-      case "not" => if (value == "yes") "no" else "yes"
-      case "pounds" => (BigDecimal(value) / 100).setScale(2).toString
-      case "trim" => value.trim
-      case unknownFunction => throw new Exception(s"Invalid function name: $unknownFunction")
+      case Right(count) => TString(value.string.takeRight(count.toInt))
+      case GreaterThan(gtInt) => if (value.string.toInt > gtInt.toInt) TString("yes") else TString("no")
+      case Contains(inStr) => if (value.string.contains(inStr)) TString("yes") else TString("no")
+      case MinusN(int) =>
+        val n = (value.string.toInt - int.toInt)
+        TString(n.toString)
+      case PlusN(int) =>
+        val n = (value.string.toInt + int.toInt)
+        TString(n.toString)
+      case "bool" => if (value.string == "true") TString("yes") else TString("no")
+      case "lower" => TString(value.string.toLowerCase)
+      case "upper" => TString(value.string.toUpperCase)
+      case "title" => TString(value.string.take(1).toUpperCase + value.string.drop(1).toLowerCase)
+      case "empty" => if (value.string.isEmpty) TString("yes") else TString("no")
+      case "not" => if (value.string == "yes") TString("no") else TString("yes")
+      case "pounds" =>
+        val d = (BigDecimal(value.string) / 100).setScale(2)
+        TString(d.toString)
+      case "trim" => TString(value.string.trim)
+      case "accountToken" =>
+        // evw membership number is only thing we ever use this function with: ((case:membershipNumber:accountToken))
+        import com.roundeights.hasher.Implicits._
+        TString(value.string.salt(appContext.config.getString("app.updateTokenSecret")).sha256.hex)
+      case unknownFunction => throw new Exception(s"Invalid function name: $unknownFunction (for a string object)")
     }).toEither
       .left.map(exc => GovNotifyError(exc.getMessage))
 
   }
 
+  def applyListFunction(value :TList, function :String) :Either[GovNotifyError, TemplateLookup] = {
+    Try(function match {
+      case "csvList" => TString(value.list.mkString(","))
+      case unknownFunction => throw new Exception(s"Invalid function name: $unknownFunction (for a list object)")
+    }).toEither
+      .left.map(exc => GovNotifyError(exc.getMessage))
+  }
+
+  def applyDateFunction(value :TDate, function :String) :Either[GovNotifyError, TemplateLookup] = {
+    val Minus = "minus(Days|Weeks|Months|Years)(\\d+)".r
+    val Plus = "plus(Days|Weeks|Months|Years)(\\d+)".r
+
+    def modify(f :DateTime => DateTime) = TDate(f(value.date))
+
+    Try(function match {
+      case "date" => TString(dtf.print(value.date))
+      case "time" => TString(value.date.toString("HH:mm"))
+      case Minus("Days", days) => modify(_.minusDays(days.toInt))
+      case Minus("Weeks", weeks) => modify(_.minusWeeks(weeks.toInt))
+      case Minus("Months", months) => modify(_.minusMonths(months.toInt))
+      case Minus("Years", years) => modify(_.minusYears(years.toInt))
+      case Plus("Days", days) => modify(_.plusDays(days.toInt))
+      case Plus("Weeks", weeks) => modify(_.plusWeeks(weeks.toInt))
+      case Plus("Months", months) => modify(_.plusMonths(months.toInt))
+      case Plus("Years", years) => modify(_.plusYears(years.toInt))
+      case "beforeNow" => if (value.date.isBefore(appContext.nowF())) TString("yes") else TString("no")
+      case unknownFunction => throw new Exception(s"Invalid function name: $unknownFunction (for a date object)")
+    }).toEither
+      .left.map(exc => GovNotifyError(exc.getMessage))
+  }
+
+  def applyFunction(value :TemplateLookup, function :String) :Either[GovNotifyError, TemplateLookup] = value match {
+    case v @ TString(_) => applyStringFunction(v, function)
+    case v @ TList(_) => applyListFunction(v, function)
+    case v @ TDate(_) => applyDateFunction(v, function)
+  }
+
   @tailrec
-  final def applyFunctions(value :String, functionList :List[String]) :Either[GovNotifyError, String] = functionList match {
+  final def applyFunctions(value :TemplateLookup, functionList :List[String]) :Either[GovNotifyError, TemplateLookup] = functionList match {
     case Nil => Right(value)
     case headFunc :: tail =>
       applyFunction(value, headFunc) match {
@@ -65,6 +105,12 @@ class TemplateFunctions(implicit appContext: AppContext) {
           applyFunctions(newValue, tail)
       }
   }
+
+  def applyFunctionsStr(value :TemplateLookup, functionsList :List[String]) :Either[GovNotifyError, String] =
+    for {
+      funcResult <- applyFunctions(value, functionsList)
+      stringifiedResult <- funcResult.stringValue()
+    } yield { stringifiedResult }
 
 }
 

--- a/src/main/scala/uk/gov/homeoffice/rtemailer/model/TemplateFunctions.scala
+++ b/src/main/scala/uk/gov/homeoffice/rtemailer/model/TemplateFunctions.scala
@@ -58,8 +58,13 @@ class TemplateFunctions(implicit appContext: AppContext) {
   }
 
   def applyListFunction(value :TList, function :String) :Either[GovNotifyError, TemplateLookup] = {
+    val Contains = "contains(.*)".r
+    val Index = "index(\\d+)".r
+
     Try(function match {
       case "csvList" => TString(value.list.mkString(","))
+      case Contains(text) => if (value.list.contains(text)) TString("yes") else TString("no")
+      case Index(idx) => TString(value.list(idx.toInt))   // throws IndexOutOfBounds intentionally
       case unknownFunction => throw new Exception(s"Invalid function name: $unknownFunction (for a list object)")
     }).toEither
       .left.map(exc => GovNotifyError(exc.getMessage))

--- a/src/test/scala/uk/gov/homeoffice/rtemailer/model/TemplateFunctionsSpec.scala
+++ b/src/test/scala/uk/gov/homeoffice/rtemailer/model/TemplateFunctionsSpec.scala
@@ -8,7 +8,11 @@ class TemplateFunctionsSpec extends CatsEffectSuite {
 
   val templateFunctions = new TemplateFunctions()(new AppContext(
     nowF = () => DateTime.parse("2024-01-01T01:02:03"),
-    ConfigFactory.empty,
+    ConfigFactory.parseString("""
+      app {
+        updateTokenSecret = "bonjour mon ami"
+      }
+    """),
     null
   ))
 
@@ -148,8 +152,21 @@ class TemplateFunctionsSpec extends CatsEffectSuite {
   }
 
   test("list stringification") {
-    assertEquals(1, 1)
+    assertEquals(testFunc(TList(List("a", "b")), "csvList"), Right(TString("a,b")))
   }
 
+  test("list contains") {
+    assertEquals(testFunc(TList(List("acorn", "ball")), "containsball"), Right(TString("yes")))
+    assertEquals(testFunc(TList(List("acorn", "ball")), "containsb"), Right(TString("no"))) /* full match expected */
+    assertEquals(testFunc(TList(List("acorn", "ball")), "containsgirl"), Right(TString("no")))
+  }
+
+  test("list index") {
+    assertEquals(testFunc(TList(List("a", "b", "c", "d", "e", "f")), "index4"), Right(TString("e")))
+  }
+
+  test("encrypted token test") {
+    assertEquals(testChain(TString("abcdefg"), "accountToken"), Right(TString("6d38446695e7c87d8895a2eb388b44ea841bed93236034366c8cc7baef18c21c")))
+  }
 }
 

--- a/src/test/scala/uk/gov/homeoffice/rtemailer/model/TemplateFunctionsSpec.scala
+++ b/src/test/scala/uk/gov/homeoffice/rtemailer/model/TemplateFunctionsSpec.scala
@@ -13,130 +13,142 @@ class TemplateFunctionsSpec extends CatsEffectSuite {
   ))
 
   def testFunc = templateFunctions.applyFunction _
-  def testChain(input :String, raw :String) = templateFunctions.applyFunctions(input, raw.split(":").toList)
+  def testChain(input :TemplateLookup, raw :String) = templateFunctions.applyFunctions(input, raw.split(":").toList)
 
   test("right") {
-    assertEquals(testFunc("hello", "right2"), Right("lo"))
-    assertEquals(testFunc("hello", "right3"), Right("llo"))
+    assertEquals(testFunc(TString("hello"), "right2"), Right(TString("lo")))
+    assertEquals(testFunc(TString("hello"), "right3"), Right(TString("llo")))
   }
 
   test("minus days") {
-    assertEquals(testFunc("01 January 2023", "minusDays2"), Right("30 December 2022"))
-    assertEquals(testFunc("07 September 2023", "minusDays6"), Right("01 September 2023"))
+    assertEquals(testFunc(TDate(DateTime.parse("2023-01-01T00:00:00Z")), "minusDays2"), Right(TDate(DateTime.parse("2022-12-30T00:00:00Z"))))
+    assertEquals(testFunc(TDate(DateTime.parse("2023-09-07T00:00:00Z")), "minusDays6"), Right(TDate(DateTime.parse("2023-09-01T00:00:00Z"))))
   }
 
   test("minus weeks") {
-    assertEquals(testFunc("01 January 2023", "minusWeeks1"), Right("25 December 2022"))
+    assertEquals(testFunc(TDate(DateTime.parse("2023-01-01T00:00:00Z")), "minusWeeks1"), Right(TDate(DateTime.parse("2022-12-25T00:00:00Z"))))
   }
 
   test("minus months") {
-    assertEquals(testFunc("30 April 2023", "minusMonths2"), Right("28 February 2023"))
+    assertEquals(testFunc(TDate(DateTime.parse("2023-04-30T00:00:00Z")), "minusMonths2"), Right(TDate(DateTime.parse("2023-02-28T00:00:00Z"))))
   }
 
   test("minus years") {
-    assertEquals(testFunc("30 April 2023", "minusYears25"), Right("30 April 1998"))
+    assertEquals(testFunc(TDate(DateTime.parse("2023-04-30T00:00:00Z")), "minusYears25"), Right(TDate(DateTime.parse("1998-04-30T00:00:00Z"))))
   }
 
   test("plus days") {
-    assertEquals(testFunc("30 December 2022", "plusDays2"), Right("01 January 2023"))
-    assertEquals(testFunc("02 September 2023", "plusDays6"), Right("08 September 2023"))
+    assertEquals(testFunc(TDate(DateTime.parse("2022-12-30T00:00:00Z")), "plusDays2"), Right(TDate(DateTime.parse("2023-01-01T00:00:00Z"))))
+    assertEquals(testFunc(TDate(DateTime.parse("2022-09-02T00:00:00Z")), "plusDays6"), Right(TDate(DateTime.parse("2022-09-08T00:00:00Z"))))
   }
 
   test("plus weeks") {
-    assertEquals(testFunc("01 January 2023", "plusWeeks1"), Right("08 January 2023"))
+    assertEquals(testFunc(TDate(DateTime.parse("2023-01-01T00:00:00Z")), "plusWeeks1"), Right(TDate(DateTime.parse("2023-01-08T00:00:00Z"))))
   }
 
   test("plus months") {
-    assertEquals(testFunc("30 April 2023", "plusMonths2"), Right("30 June 2023"))
+    assertEquals(testFunc(TDate(DateTime.parse("2023-04-30T00:00:00Z")), "plusMonths2"), Right(TDate(DateTime.parse("2023-06-30T00:00:00Z"))))
   }
 
   test("plus years") {
-    assertEquals(testFunc("30 April 2023", "plusYears1"), Right("30 April 2024"))
+    assertEquals(testFunc(TDate(DateTime.parse("2023-04-30T00:00:00Z")), "plusYears1"), Right(TDate(DateTime.parse("2024-04-30T00:00:00Z"))))
   }
 
   test("beforeNow") {
     // At top of file we mock nowF to be 1st Jan 2024
-    assertEquals(testFunc("31 December 2023", "beforeNow"), Right("yes"))
-    assertEquals(testFunc("01 January 2024", "beforeNow"), Right("yes"))
-    assertEquals(testFunc("02 January 2024", "beforeNow"), Right("no"))
+    assertEquals(testFunc(TDate(DateTime.parse("2023-12-31T00:00:00Z")), "beforeNow"), Right(TString("yes")))
+    assertEquals(testFunc(TDate(DateTime.parse("2024-01-01T00:00:00Z")), "beforeNow"), Right(TString("yes")))
+    assertEquals(testFunc(TDate(DateTime.parse("2024-02-01T00:00:00Z")), "beforeNow"), Right(TString("no")))
+  }
+
+  test("date and time") {
+    assertEquals(testFunc(TDate(DateTime.parse("2024-04-01T00:00:00Z")), "date"), Right(TString("01 April 2024")))
+    assertEquals(testFunc(TDate(DateTime.parse("2020-06-01T12:00:00Z")), "date"), Right(TString("01 June 2020")))
+    assertEquals(testFunc(TDate(DateTime.parse("2024-01-01T12:30:20Z")), "time"), Right(TString("12:30")))
   }
 
   test("chained date functions") {
-    assertEquals(testFunc("01 January 2024", "beforeNow"), Right("yes"))
-    assertEquals(testChain("01 January 2024", "beforeNow:not"), Right("no"))
-    assertEquals(testChain("01 January 2024", "plusYears1:beforeNow:not"), Right("yes"))
+    assertEquals(testFunc(TDate(DateTime.parse("2024-01-01T00:00:00Z")), "beforeNow"), Right(TString("yes")))
+    assertEquals(testChain(TDate(DateTime.parse("2024-01-01T00:00:00Z")), "beforeNow:not"), Right(TString("no")))
+    assertEquals(testChain(TDate(DateTime.parse("2024-01-01T00:00:00Z")), "plusYears1:beforeNow:not"), Right(TString("yes")))
+    assertEquals(testChain(TDate(DateTime.parse("2024-01-01T00:00:00Z")), "plusYears1:beforeNow:not"), Right(TString("yes")))
+    assertEquals(testChain(TDate(DateTime.parse("2024-01-01T00:00:00Z")), "plusYears1:date"), Right(TString("01 January 2025")))
   }
 
   test("greater than (gt)") {
-    assertEquals(testFunc("12", "gt13"), Right("no"))
-    assertEquals(testFunc("13", "gt13"), Right("no"))
-    assertEquals(testFunc("14", "gt13"), Right("yes"))
-    assertEquals(testChain("14", "gt13:not"), Right("no"))
-    assertEquals(testFunc("5000", "gt7000"), Right("no"))
+    assertEquals(testFunc(TString("12"), "gt13"), Right(TString("no")))
+    assertEquals(testFunc(TString("13"), "gt13"), Right(TString("no")))
+    assertEquals(testFunc(TString("14"), "gt13"), Right(TString("yes")))
+    assertEquals(testChain(TString("14"), "gt13:not"), Right(TString("no")))
+    assertEquals(testFunc(TString("5000"), "gt7000"), Right(TString("no")))
   }
 
   test("contains") {
-    assertEquals(testFunc("help", "containshelp"), Right("yes"))
-    assertEquals(testFunc("help", "containsel"), Right("yes"))
-    assertEquals(testFunc("help", "containsHELP"), Right("no"))
-    assertEquals(testFunc("help", "containsChipmonk"), Right("no"))
+    assertEquals(testFunc(TString("help"), "containshelp"), Right(TString("yes")))
+    assertEquals(testFunc(TString("help"), "containsel"), Right(TString("yes")))
+    assertEquals(testFunc(TString("help"), "containsHELP"), Right(TString("no")))
+    assertEquals(testFunc(TString("help"), "containsChipmonk"), Right(TString("no")))
   }
 
   test("minusN") {
-    assertEquals(testFunc("16", "minusN10"), Right("6"))
-    assertEquals(testFunc("36", "minusN20"), Right("16"))
+    assertEquals(testFunc(TString("16"), "minusN10"), Right(TString("6")))
+    assertEquals(testFunc(TString("36"), "minusN20"), Right(TString("16")))
   }
 
   test("plusN") {
-    assertEquals(testFunc("10", "plusN5"), Right("15"))
-    assertEquals(testFunc("5", "plusN100"), Right("105"))
+    assertEquals(testFunc(TString("10"), "plusN5"), Right(TString("15")))
+    assertEquals(testFunc(TString("5"), "plusN100"), Right(TString("105")))
   }
 
   test("bool") {
-    assertEquals(testFunc("true", "bool"), Right("yes"))
-    assertEquals(testFunc("false", "bool"), Right("no"))
-    assertEquals(testFunc("anythingelse", "bool"), Right("no"))
-    assertEquals(testFunc("yes", "bool"), Right("no")) /* expected! */
+    assertEquals(testFunc(TString("true"), "bool"), Right(TString("yes")))
+    assertEquals(testFunc(TString("false"), "bool"), Right(TString("no")))
+    assertEquals(testFunc(TString("anythingelse"), "bool"), Right(TString("no")))
+    assertEquals(testFunc(TString("yes"), "bool"), Right(TString("no"))) /* expected! */
   }
 
   test("lower") {
-    assertEquals(testFunc("CraFty", "lower"), Right("crafty"))
+    assertEquals(testFunc(TString("CraFty"), "lower"), Right(TString("crafty")))
   }
 
   test("upper") {
-    assertEquals(testFunc("CraFty", "upper"), Right("CRAFTY"))
+    assertEquals(testFunc(TString("CraFty"), "upper"), Right(TString("CRAFTY")))
   }
 
   test("title") {
-    assertEquals(testFunc("craFty", "title"), Right("Crafty"))
+    assertEquals(testFunc(TString("craFty"), "title"), Right(TString("Crafty")))
   }
 
   test("empty") {
-    assertEquals(testFunc("craFty", "empty"), Right("no"))
-    assertEquals(testFunc("", "empty"), Right("yes"))
+    assertEquals(testFunc(TString("craFty"), "empty"), Right(TString("no")))
+    assertEquals(testFunc(TString(""), "empty"), Right(TString("yes")))
   }
 
   test("not") {
-    assertEquals(testFunc("yes", "not"), Right("no"))
-    assertEquals(testFunc("no", "not"), Right("yes"))
-    assertEquals(testFunc("anythingelse", "not"), Right("yes"))
+    assertEquals(testFunc(TString("yes"), "not"), Right(TString("no")))
+    assertEquals(testFunc(TString("no"), "not"), Right(TString("yes")))
+    assertEquals(testFunc(TString("anythingelse"), "not"), Right(TString("yes")))
   }
 
   test("pounds") {
-    assertEquals(testFunc("5000", "pounds"), Right("50.00"))
-    assertEquals(testFunc("1234", "pounds"), Right("12.34"))
+    assertEquals(testFunc(TString("5000"), "pounds"), Right(TString("50.00")))
+    assertEquals(testFunc(TString("1234"), "pounds"), Right(TString("12.34")))
   }
 
   test("trim") {
-    assertEquals(testFunc("PHIL", "trim"), Right("PHIL"))
-    assertEquals(testFunc("   PHIL   WAS ", "trim"), Right("PHIL   WAS"))
+    assertEquals(testFunc(TString("PHIL"), "trim"), Right(TString("PHIL")))
+    assertEquals(testFunc(TString("   PHIL   WAS "), "trim"), Right(TString("PHIL   WAS")))
   }
 
   test("chained functions") {
-    assertEquals(testChain("   PHIL TAY   ", "trim:right3:title"), Right("Tay"))
-    assertEquals(testChain("   PHIL TAY   ", "trim:empty:not"), Right("yes"))
-    assertEquals(testChain("      ", "trim:empty:not"), Right("no"))
-    assertEquals(testChain("TRUE", "lower:bool:not:not"), Right("yes"))
+    assertEquals(testChain(TString("   PHIL TAY   "), "trim:right3:title"), Right(TString("Tay")))
+    assertEquals(testChain(TString("   PHIL TAY   "), "trim:empty:not"), Right(TString("yes")))
+    assertEquals(testChain(TString("      "), "trim:empty:not"), Right(TString("no")))
+    assertEquals(testChain(TString("TRUE"), "lower:bool:not:not"), Right(TString("yes")))
+  }
+
+  test("list stringification") {
+    assertEquals(1, 1)
   }
 
 }


### PR DESCRIPTION
1. functions are typed now, to support MongoDBList objects more elegantly. A field extracted from the DB will be either a TString, a TDate or a TList. TList can be converted to a string with new csvList function. TDates can print dates or times now.

2. The email collection can now contain a personalisation's field. The current implementation assumed all template fields could be populated from a case:, config: or parent:. However some information that goes into EVW Awaiting Info emails isn't persisted in a useful way. Now we support storing arbitrary data in the personalisations field of the email collection. Templates can contain a new email: prefix, e.g. email:personalisations.keyDetailsChanged:csvList. access to the email: field also gives access to email:recipient.

3. Some of the code has been refactored. A new govnotify package exists.