### PR TITLE
DPSPS-1553: Fix a bug with "parent:" syntax from GovNotify

### DIFF
--- a/src/main/scala/uk/gov/homeoffice/rtemailer/database/LegacyMongoDatabase.scala
+++ b/src/main/scala/uk/gov/homeoffice/rtemailer/database/LegacyMongoDatabase.scala
@@ -117,13 +117,23 @@ class LegacyMongoDatabase(config :Config) extends Database with StrictLogging {
     lazy val caseTable :String = config.getString("govNotify.caseTable")
 
     extractDBField(caseObj, "latestApplication.parentRegisteredTravellerNumber") match {
-      case Some(parentRT) => IO.blocking { Try(
-        mongoDB_(caseTable).findOne(MongoDBObject("registeredTravellerNumber"-> parentRT.stringValue().right.get))).toEither
-          .map { _.map(new MongoDBObject(_)) }
-          .left.map(exc => GovNotifyError(s"Database error looking up parent case from case: ${exc.getMessage()}")
-        )}
-
-      case None => IO.delay(Right(None))
+      case Some(parentRT) => IO.blocking {
+        parentRT.stringValue() match {
+          case Right(parentRTString) =>
+            Try(mongoDB_(caseTable).findOne(MongoDBObject("registeredTravellerNumber"-> parentRTString))).toEither
+              .map { _.map(new MongoDBObject(_)) }
+              .left.map { exc =>
+                logger.info(s"Database error looking up parent case (caseId: ${caseObj.get("_id").toString}): ${exc.getMessage()}")
+                GovNotifyError(s"Database error looking up parent case from case: ${exc.getMessage()}")
+              }
+          case Left(exc) =>
+            logger.info(s"latestApplication.parentRegisteredTravellerNumber was not a string (${caseObj.get("_id")})")
+            Right(None)
+        }
+      }
+      case None =>
+        logger.info(s"No latestApplication.parentRegisteredTravellerNumber in caseObj (${caseObj.get("_id")})")
+        IO.delay(Right(None))
     }
   }
 }

--- a/src/test/scala/uk/gov/homeoffice/rtemailer/database/LegacyMongoDatabaseSpec.scala
+++ b/src/test/scala/uk/gov/homeoffice/rtemailer/database/LegacyMongoDatabaseSpec.scala
@@ -1,0 +1,83 @@
+package uk.gov.homeoffice.rtemailer.database
+
+import munit.CatsEffectSuite
+import cats.effect._
+import org.joda.time.DateTime
+import com.typesafe.config.ConfigFactory
+import uk.gov.homeoffice.rtemailer.model.AppContext
+import org.bson.types.ObjectId
+import uk.gov.homeoffice.rtemailer.emailsender._
+
+import com.mongodb.casbah.commons.MongoDBObject
+
+class LegacyMongoDatabaseSpec extends CatsEffectSuite {
+
+  test("parent lookup inc. database calls works") {
+
+    val childSubmissionId = new ObjectId()
+    val now = DateTime.now()
+
+    val childCaseObject = MongoDBObject(
+      "_id" -> childSubmissionId,
+      "registeredTravellerNumber" -> "RT-CHILD",
+      "name" -> "Dillon",
+      "latestApplication" -> MongoDBObject("parentRegisteredTravellerNumber" -> "RT-PARENT")
+    )
+
+    val parentCaseObject = MongoDBObject(
+      "registeredTravellerNumber" -> "RT-PARENT",
+      "name" -> "Jullian"
+    )
+
+    val emailObject = MongoDBObject(
+      "caseId" -> childSubmissionId,
+      "recipient" -> "test@example.com",
+      "status" -> "WAITING",
+      "type" -> "Under 18 Application Receieved",
+      "cc" -> List.empty[String],
+      "subject" -> "Under 18"
+    )
+
+    val config = ConfigFactory.parseString("""
+      app {
+        templateDebug = false
+      }
+      db {
+        host = "localhost"
+        name = "rt-emailer"
+        user = ""
+        password = ""
+        params = ""
+      }
+      govNotify {
+        apiKey = "1234"
+        apiKey2 = ""
+        caseTable = "submissions"
+        staticPersonalisations {
+          rt_customer_host = "https://rt.example.com"
+          ge_customer_host = "https://ge.example.com"
+          rtge_caseworker_host = "https://rtgecaseworker.example.com"
+          rt_new_application_fee = 7000
+        }
+      }
+    """)
+
+    val legacyMongoDatabase = new LegacyMongoDatabase(config)
+
+    val appContext = AppContext(
+      nowF = { () => now },
+      config = config,
+      database = legacyMongoDatabase,
+      statsDClient = null
+    )
+
+    legacyMongoDatabase.mongoDB_("submissions").insert(childCaseObject)
+    legacyMongoDatabase.mongoDB_("submissions").insert(parentCaseObject)
+    legacyMongoDatabase.mongoDB_("email").insert(emailObject)
+
+    // Test begins here.
+    val govNotifyEmailSender = new GovNotifyEmailSender()(appContext)
+    val result = govNotifyEmailSender.buildParentPersonalisations(List("parent:name"), Some(new MongoDBObject(childCaseObject)), "my template").unsafeRunSync()
+    assertEquals(result.right.get, Map("parent:name" -> "Jullian"))
+  }
+}


### PR DESCRIPTION
parentRT.stringValue() returns an Either[] which was being put into a MongoDBObject incorrectly