### PR TITLE
DPSPS-1561: Change the field "parent" syntax uses to find the parent

### DIFF
--- a/src/main/scala/uk/gov/homeoffice/rtemailer/database/LegacyMongoDatabase.scala
+++ b/src/main/scala/uk/gov/homeoffice/rtemailer/database/LegacyMongoDatabase.scala
@@ -116,7 +116,7 @@ class LegacyMongoDatabase(config :Config) extends Database with StrictLogging {
   def parentObjectFromCaseObject(caseObj :MongoDBObject)(implicit appContext :AppContext) :IO[Either[GovNotifyError, Option[MongoDBObject]]] = {
     lazy val caseTable :String = config.getString("govNotify.caseTable")
 
-    extractDBField(caseObj, "latestApplication.parentRegisteredTravellerNumber") match {
+    extractDBField(caseObj, "parentRegisteredTravellerNumber") match {
       case Some(parentRT) => IO.blocking {
         parentRT.stringValue() match {
           case Right(parentRTString) =>
@@ -127,12 +127,12 @@ class LegacyMongoDatabase(config :Config) extends Database with StrictLogging {
                 GovNotifyError(s"Database error looking up parent case from case: ${exc.getMessage()}")
               }
           case Left(exc) =>
-            logger.info(s"latestApplication.parentRegisteredTravellerNumber was not a string (${caseObj.get("_id")})")
+            logger.info(s"parentRegisteredTravellerNumber was not a string (${caseObj.get("_id")})")
             Right(None)
         }
       }
       case None =>
-        logger.info(s"No latestApplication.parentRegisteredTravellerNumber in caseObj (${caseObj.get("_id")})")
+        logger.info(s"No parentRegisteredTravellerNumber in caseObj (${caseObj.get("_id")})")
         IO.delay(Right(None))
     }
   }

--- a/src/test/scala/uk/gov/homeoffice/rtemailer/database/LegacyMongoDatabaseSpec.scala
+++ b/src/test/scala/uk/gov/homeoffice/rtemailer/database/LegacyMongoDatabaseSpec.scala
@@ -21,7 +21,7 @@ class LegacyMongoDatabaseSpec extends CatsEffectSuite {
       "_id" -> childSubmissionId,
       "registeredTravellerNumber" -> "RT-CHILD",
       "name" -> "Dillon",
-      "latestApplication" -> MongoDBObject("parentRegisteredTravellerNumber" -> "RT-PARENT")
+      "parentRegisteredTravellerNumber" -> "RT-PARENT"
     )
 
     val parentCaseObject = MongoDBObject(

--- a/src/test/scala/uk/gov/homeoffice/rtemailer/emailsender/GovNotifyEmailSenderSpec.scala
+++ b/src/test/scala/uk/gov/homeoffice/rtemailer/emailsender/GovNotifyEmailSenderSpec.scala
@@ -155,7 +155,7 @@ class govNotifyEmailSenderSpec extends CatsEffectSuite {
           "details" -> MongoDBObject("age" -> 17),
           "boolField" -> "True", // not a bool field, but a string that can be molded into a boolean field
           "dateOfBirth" -> DateTime.parse("2023-02-01T13:44:55"),
-          "latestApplication" -> MongoDBObject("parentRegisteredTravellerNumber" -> "RT65")
+          "parentRegisteredTravellerNumber" -> "RT65"
         )))))
         case Some(_) =>
           IO.delay(Right(Some(new MongoDBObject(MongoDBObject(
@@ -171,7 +171,7 @@ class govNotifyEmailSenderSpec extends CatsEffectSuite {
 
     override def parentObjectFromCaseObject(caseObj :MongoDBObject)(implicit appContext :AppContext) :IO[Either[GovNotifyError, Option[MongoDBObject]]] = {
       // pretend scenario
-      caseObj.getAs[String]("latestApplication.parentRegisteredTravellerNumber") match {
+      caseObj.getAs[String]("parentRegisteredTravellerNumber") match {
         case Some("RT65") =>
           IO.delay(Right(Some(new MongoDBObject(MongoDBObject(
             "registeredTravellerNumber" -> "RT65",
@@ -238,7 +238,7 @@ class govNotifyEmailSenderSpec extends CatsEffectSuite {
 
   test("extracting parameters from a parent object works (in isolation)") {
     val testCase = new MongoDBObject(MongoDBObject(
-      "latestApplication" -> MongoDBObject("parentRegisteredTravellerNumber" -> "RT65"),
+      "parentRegisteredTravellerNumber" -> "RT65",
       "name" -> "phillip",
       "details" -> MongoDBObject("age" -> 17)
     ))


### PR DESCRIPTION
Under18 renewal and updates don't include the field in latestApplication so use the value against the root of the structure.

parent syntax is a HO specific feature that other rt-emailer clients won't need to concern themselves with.